### PR TITLE
Fix errors, add new colors and basic auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vscode/ipch
 doc/wiring.pptx
 builds
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -173,11 +173,12 @@ As the name already says this will delete all your settings and fingerprints fro
 | -------- | -------- | -------- |
 | red | permanent | System is in error state |
 | red | breathing | System in WiFi config mode |
-| red | flashing  | Finger on sensor detected (no match found yet) |
-| blue | permanent | System ready (touch ring ignored) |
-| blue | breathing | System ready (touch ring active) |
+| white | flashing  | Finger on sensor detected (no match found yet) |
+| white | permanent | System ready (touch ring ignored) |
+| white | breathing | System ready (touch ring active) |
 | blue | flashing | System startup (not ready yet) |
-| purple | solid | Fingerprint match found or when in enrollment mode this means pass is finished, lift your finger |
+| green | solid | Fingerprint match found |
+| purple | solid | In enrollment mode this means pass is finished, lift your finger |
 | purple | flashing | Enrollment active (waiting for finger) |
 
 ## What is the MQTT topic "fingerprintDoorbell/ignoreTouchRing" for and how to use it?

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,12 +9,13 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env:esp32doit-devkit-v1]
-platform = espressif32
+platform = espressif32@3.5.0
 board = esp32doit-devkit-v1
 framework = arduino
 monitor_speed = 115200
 lib_deps = 
 	me-no-dev/ESP Async WebServer@^1.2.3
+	https://github.com/ayushsharma82/AsyncElegantOTA/archive/refs/heads/master.zip
 	ayushsharma82/AsyncElegantOTA@^2.2.6
 	knolleary/PubSubClient@^2.8
 	adafruit/Adafruit Fingerprint Sensor Library@^2.0.7

--- a/src/FingerprintManager.cpp
+++ b/src/FingerprintManager.cpp
@@ -54,7 +54,7 @@ void FingerprintManager::updateTouchState(bool touched)
       // check if sensor or ring is touched
       if (touched) {
         // turn touch indicator on:
-        finger.LEDcontrol(FINGERPRINT_LED_FLASHING, 25, FINGERPRINT_LED_RED, 0);
+        finger.LEDcontrol(FINGERPRINT_LED_FLASHING, 25, FINGERPRINT_LED_WHITE, 0);
       } else {
         // turn touch indicator off:
         setLedRingReady();
@@ -189,7 +189,8 @@ Match FingerprintManager::scanFingerprint() {
     match.returnCode = finger.fingerSearch();
     if (match.returnCode == FINGERPRINT_OK) {
         // found a match!
-        finger.LEDcontrol(FINGERPRINT_LED_ON, 0, FINGERPRINT_LED_PURPLE);
+        finger.LEDcontrol(FINGERPRINT_LED_ON, 0, FINGERPRINT_LED_GREEN);
+        // to use green add "#define FINGERPRINT_LED_GREEN 0x04      //!< Green LED" to  libdeps / esp32doit-devkit-v1 -> Adafruit Fingerprint Sensor Libary -> Adafruit_Fingerprint.h
         
         match.scanResult = ScanResult::matchFound;
         match.matchId = finger.fingerID;
@@ -457,9 +458,9 @@ void FingerprintManager::setLedRingWifiConfig() {
 
 void FingerprintManager::setLedRingReady() {
   if (!ignoreTouchRing)
-    finger.LEDcontrol(FINGERPRINT_LED_BREATHING, 250, FINGERPRINT_LED_BLUE);
+    finger.LEDcontrol(FINGERPRINT_LED_ON, 0, FINGERPRINT_LED_WHITE);
   else
-    finger.LEDcontrol(FINGERPRINT_LED_ON, 0, FINGERPRINT_LED_BLUE); // just an indicator for me to see if touch ring is active or not
+    finger.LEDcontrol(FINGERPRINT_LED_ON, 0, FINGERPRINT_LED_WHITE); // just an indicator for me to see if touch ring is active or not
 }
 
 bool FingerprintManager::deleteAll() {

--- a/src/FingerprintManager.cpp
+++ b/src/FingerprintManager.cpp
@@ -55,6 +55,7 @@ void FingerprintManager::updateTouchState(bool touched)
       if (touched) {
         // turn touch indicator on:
         finger.LEDcontrol(FINGERPRINT_LED_FLASHING, 25, FINGERPRINT_LED_WHITE, 0);
+        // to use white add "#define FINGERPRINT_LED_WHITE 0x07      //!< Green LED" to  .pio -> libdeps / esp32doit-devkit-v1 -> Adafruit Fingerprint Sensor Libary -> Adafruit_Fingerprint.h
       } else {
         // turn touch indicator off:
         setLedRingReady();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,10 @@ const char* WifiConfigSsid = "FingerprintDoorbell-Config"; // SSID used for WiFi
 const char* WifiConfigPassword = "12345678"; // password used for WiFi when in Access Point mode for configuration. Min. 8 chars needed!
 IPAddress   WifiConfigIp(192, 168, 4, 1); // IP of access point in wifi config mode
 
+// ====== UI Login Credentials ====== //
+const char* http_username = "admin";
+const char* http_password = "fingerprintdoorbell";
+
 const long  gmtOffset_sec = 0; // UTC Time
 const int   daylightOffset_sec = 0; // UTC Time
 const int   doorbellOutputPin = 19; // pin connected to the doorbell (when using hardware connection instead of mqtt to ring the bell)
@@ -314,10 +318,14 @@ void startWebserver(){
     
     // Route for root / web page
     webServer.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+      if(!request->authenticate(http_username, http_password))
+          return request->requestAuthentication();
       request->send(SPIFFS, "/index.html", String(), false, processor);
     });
 
     webServer.on("/enroll", HTTP_GET, [](AsyncWebServerRequest *request){
+      if(!request->authenticate(http_username, http_password))
+          return request->requestAuthentication();
       if(request->hasArg("startEnrollment"))
       {
         enrollId = request->arg("newFingerprintId");
@@ -328,6 +336,8 @@ void startWebserver(){
     });
 
     webServer.on("/editFingerprints", HTTP_GET, [](AsyncWebServerRequest *request){
+      if(!request->authenticate(http_username, http_password))
+          return request->requestAuthentication();
       if(request->hasArg("selectedFingerprint"))
       {
         if(request->hasArg("btnDelete"))
@@ -348,6 +358,8 @@ void startWebserver(){
     });
 
     webServer.on("/settings", HTTP_GET, [](AsyncWebServerRequest *request){
+      if(!request->authenticate(http_username, http_password))
+          return request->requestAuthentication();
       if(request->hasArg("btnSaveSettings"))
       {
         Serial.println("Save settings");
@@ -367,6 +379,8 @@ void startWebserver(){
 
 
     webServer.on("/pairing", HTTP_GET, [](AsyncWebServerRequest *request){
+      if(!request->authenticate(http_username, http_password))
+          return request->requestAuthentication();
       if(request->hasArg("btnDoPairing"))
       {
         Serial.println("Do (re)pairing");
@@ -380,6 +394,8 @@ void startWebserver(){
 
 
     webServer.on("/factoryReset", HTTP_GET, [](AsyncWebServerRequest *request){
+      if(!request->authenticate(http_username, http_password))
+          return request->requestAuthentication();
       if(request->hasArg("btnFactoryReset"))
       {
         notifyClients("Factory reset initiated...");
@@ -402,6 +418,8 @@ void startWebserver(){
 
 
     webServer.on("/deleteAllFingerprints", HTTP_GET, [](AsyncWebServerRequest *request){
+      if(!request->authenticate(http_username, http_password))
+          return request->requestAuthentication();
       if(request->hasArg("btnDeleteAllFingerprints"))
       {
         notifyClients("Deleting all fingerprints...");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -557,7 +557,7 @@ void doScan()
           notifyClients("Security issue! Match was not sent by MQTT because of invalid sensor pairing! This could potentially be an attack! If the sensor is new or has been replaced by you do a (re)pairing in settings page.");
         }
       }
-      delay(3000); // wait some time before next scan to let the LED blink
+      delay(1000); // wait some time before next scan to let the LED blink
       break;
     case ScanResult::noMatchFound:
       notifyClients(String("No Match Found (Code ") + match.returnCode + ")");


### PR DESCRIPTION
### Changes:

- Update espressif32 to 3.5.0 & fix async webserver
- Changed led basic color to white. Led breathing at ready state changed to static. Led ring blinks blue at starting up.
Important: New color need to be defined at .pio -> libdeps / esp32doit-devkit-v1 -> Adafruit Fingerprint Sensor Libary -> Adafruit_Fingerprint.h
- Fingerprint confirmation turn green color on for 1 second
- Simple basic web auth added so the UI is no free accessible in the network (maybe the credentials should better be configurable at web ui?!)

I'm open for adjustments if some changes may are not useful or may not added correctly.