### PR TITLE
color and sequence configurable in web interface, port number for mqtt server

### DIFF
--- a/data/settings.html
+++ b/data/settings.html
@@ -109,6 +109,44 @@
 		</div>
 	</div>
 
+	<div class="form-group">
+		<label for="select" class="control-label col-xs-4">Touch Ring Active</label> 
+		<div class="col-xs-4">
+			<select id="touchRingActiveColor" name="touchRingActiveColor" aria-describedby="selectHelpBlock" class="select form-control">
+				<option value="1" %TOUCH_RING_ACTIVE_COLOR_1%>Red</option>
+				<option value="2" %TOUCH_RING_ACTIVE_COLOR_2%>Blue</option>
+				<option value="3" %TOUCH_RING_ACTIVE_COLOR_3%>Purple</option>
+				<option value="4" %TOUCH_RING_ACTIVE_COLOR_4%>Green</option>
+				<option value="5" %TOUCH_RING_ACTIVE_COLOR_5%>Yellow</option>
+				<option value="6" %TOUCH_RING_ACTIVE_COLOR_6%>Cyan</option>
+				<option value="7" %TOUCH_RING_ACTIVE_COLOR_7%>White</option>
+			</select> 
+			<span id="selectHelpBlock" class="help-block">Latest version of R503 supports seven colors !</span>
+		</div>
+	</div>
+	<div class="form-group">
+		<label for="radio" class="control-label col-xs-4"></label> 
+		<div class="col-xs-4">
+			<label class="radio-inline">
+				<input type="radio" name="touchRingActiveSequence" value="4" %TOUCH_RING_ACTIVE_SEQUENCE_4%>
+					Off
+			</label>
+			<label class="radio-inline">
+			<input type="radio" name="touchRingActiveSequence" value="3" %TOUCH_RING_ACTIVE_SEQUENCE_3%>
+					On
+			</label>
+			<label class="radio-inline">
+			<input type="radio" name="touchRingActiveSequence" value="1" %TOUCH_RING_ACTIVE_SEQUENCE_1%>
+					Breath
+			</label> 
+			<label class="radio-inline">
+			<input type="radio" name="touchRingActiveSequence" value="2" %TOUCH_RING_ACTIVE_SEQUENCE_2%>
+					Blink
+			</label> 
+			<span id="radioHelpBlock" class="help-block">Sequence</span>
+		</div>
+	</div> 
+
 	<!-- Button -->
 	<div class="form-group">
 	  <label class="col-md-4 control-label" for="btnSaveSettings"></label>

--- a/data/settings.html
+++ b/data/settings.html
@@ -145,6 +145,36 @@
 			</label> 
 		</div>
 	</div> 
+	<div class="form-group">
+		<label for="scanColor" class="col-md-4 control-label">Scan fingerprint: LED Color</label> 
+		<div class="col-md-4">
+			<select id="scanColor" name="scanColor" class="select form-control">
+				<option value="1" %SCAN_COLOR_1%>Red</option>
+				<option value="2" %SCAN_COLOR_2%>Blue</option>
+				<option value="3" %SCAN_COLOR_3%>Purple</option>
+				<option value="4" %SCAN_COLOR_4%>Green</option>
+				<option value="5" %SCAN_COLOR_5%>Yellow</option>
+				<option value="6" %SCAN_COLOR_6%>Cyan</option>
+				<option value="7" %SCAN_COLOR_7%>White</option>
+			</select> 
+			<small class="text-muted">Not all versions of the R503 sensor supports all colors. Older ones only red, blue and purple!</small>
+		</div>
+	</div>
+	<div class="form-group">
+		<label for="matchColor" class="col-md-4 control-label">Matching fingerprint: LED Color</label> 
+		<div class="col-md-4">
+			<select id="matchColor" name="matchColor" class="select form-control">
+				<option value="1" %MATCH_COLOR_1%>Red</option>
+				<option value="2" %MATCH_COLOR_2%>Blue</option>
+				<option value="3" %MATCH_COLOR_3%>Purple</option>
+				<option value="4" %MATCH_COLOR_4%>Green</option>
+				<option value="5" %MATCH_COLOR_5%>Yellow</option>
+				<option value="6" %MATCH_COLOR_6%>Cyan</option>
+				<option value="7" %MATCH_COLOR_7%>White</option>
+			</select> 
+			<small class="text-muted">Not all versions of the R503 sensor supports all colors. Older ones only red, blue and purple!</small>
+		</div>
+	</div>
 
 	<!-- Button -->
 	<div class="form-group">

--- a/data/settings.html
+++ b/data/settings.html
@@ -110,8 +110,8 @@
 	</div>
 
 	<div class="form-group">
-		<label for="select" class="control-label col-xs-4">Touch Ring Active</label> 
-		<div class="col-xs-4">
+		<label for="select" class="col-md-4 control-label">Touch Ring Active: LED Color</label> 
+		<div class="col-md-4">
 			<select id="touchRingActiveColor" name="touchRingActiveColor" aria-describedby="selectHelpBlock" class="select form-control">
 				<option value="1" %TOUCH_RING_ACTIVE_COLOR_1%>Red</option>
 				<option value="2" %TOUCH_RING_ACTIVE_COLOR_2%>Blue</option>
@@ -121,12 +121,12 @@
 				<option value="6" %TOUCH_RING_ACTIVE_COLOR_6%>Cyan</option>
 				<option value="7" %TOUCH_RING_ACTIVE_COLOR_7%>White</option>
 			</select> 
-			<span id="selectHelpBlock" class="help-block">Latest version of R503 supports seven colors !</span>
+			<small class="text-muted">Not all versions of then R503 sensor supports all colors. Older ones only red, blue and purple!</small>
 		</div>
 	</div>
 	<div class="form-group">
-		<label for="radio" class="control-label col-xs-4"></label> 
-		<div class="col-xs-4">
+		<label for="radio" class="col-md-4 control-label">Touch Ring Active: LED Sequence</label> 
+		<div class="col-md-4">
 			<label class="radio-inline">
 				<input type="radio" name="touchRingActiveSequence" value="4" %TOUCH_RING_ACTIVE_SEQUENCE_4%>
 					Off
@@ -143,7 +143,6 @@
 			<input type="radio" name="touchRingActiveSequence" value="2" %TOUCH_RING_ACTIVE_SEQUENCE_2%>
 					Blink
 			</label> 
-			<span id="radioHelpBlock" class="help-block">Sequence</span>
 		</div>
 	</div> 
 

--- a/data/settings.html
+++ b/data/settings.html
@@ -110,9 +110,9 @@
 	</div>
 
 	<div class="form-group">
-		<label for="select" class="col-md-4 control-label">Touch Ring Active: LED Color</label> 
+		<label for="touchRingActiveColor" class="col-md-4 control-label">Touch Ring Active: LED Color</label> 
 		<div class="col-md-4">
-			<select id="touchRingActiveColor" name="touchRingActiveColor" aria-describedby="selectHelpBlock" class="select form-control">
+			<select id="touchRingActiveColor" name="touchRingActiveColor" class="select form-control">
 				<option value="1" %TOUCH_RING_ACTIVE_COLOR_1%>Red</option>
 				<option value="2" %TOUCH_RING_ACTIVE_COLOR_2%>Blue</option>
 				<option value="3" %TOUCH_RING_ACTIVE_COLOR_3%>Purple</option>
@@ -121,27 +121,27 @@
 				<option value="6" %TOUCH_RING_ACTIVE_COLOR_6%>Cyan</option>
 				<option value="7" %TOUCH_RING_ACTIVE_COLOR_7%>White</option>
 			</select> 
-			<small class="text-muted">Not all versions of then R503 sensor supports all colors. Older ones only red, blue and purple!</small>
+			<small class="text-muted">Not all versions of the R503 sensor supports all colors. Older ones only red, blue and purple!</small>
 		</div>
 	</div>
 	<div class="form-group">
-		<label for="radio" class="col-md-4 control-label">Touch Ring Active: LED Sequence</label> 
+		<label for="touchRingActiveSequence" class="col-md-4 control-label">Touch Ring Active: LED Sequence</label> 
 		<div class="col-md-4">
 			<label class="radio-inline">
-				<input type="radio" name="touchRingActiveSequence" value="4" %TOUCH_RING_ACTIVE_SEQUENCE_4%>
-					Off
+			<input type="radio" name="touchRingActiveSequence" value="4" %TOUCH_RING_ACTIVE_SEQUENCE_4%>
+				Off
 			</label>
 			<label class="radio-inline">
 			<input type="radio" name="touchRingActiveSequence" value="3" %TOUCH_RING_ACTIVE_SEQUENCE_3%>
-					On
+				On
 			</label>
 			<label class="radio-inline">
 			<input type="radio" name="touchRingActiveSequence" value="1" %TOUCH_RING_ACTIVE_SEQUENCE_1%>
-					Breath
+				Breath
 			</label> 
 			<label class="radio-inline">
 			<input type="radio" name="touchRingActiveSequence" value="2" %TOUCH_RING_ACTIVE_SEQUENCE_2%>
-					Blink
+				Blink
 			</label> 
 		</div>
 	</div> 

--- a/src/FingerprintManager.cpp
+++ b/src/FingerprintManager.cpp
@@ -54,7 +54,7 @@ void FingerprintManager::updateTouchState(bool touched)
       // check if sensor or ring is touched
       if (touched) {
         // turn touch indicator on:
-        finger.LEDcontrol(FINGERPRINT_LED_FLASHING, 25, FINGERPRINT_LED_RED, 0);
+        finger.LEDcontrol(FINGERPRINT_LED_FLASHING, 25, scanColor, 0);
       } else {
         // turn touch indicator off:
         setLedRingReady();
@@ -189,7 +189,7 @@ Match FingerprintManager::scanFingerprint() {
     match.returnCode = finger.fingerSearch();
     if (match.returnCode == FINGERPRINT_OK) {
         // found a match!
-        finger.LEDcontrol(FINGERPRINT_LED_ON, 0, FINGERPRINT_LED_PURPLE);
+        finger.LEDcontrol(FINGERPRINT_LED_ON, 0, matchColor);
         
         match.scanResult = ScanResult::matchFound;
         match.matchId = finger.fingerID;
@@ -558,7 +558,9 @@ void FingerprintManager::importSensorDB() {
 
 }
 
-void FingerprintManager::configTouchRingActive(uint8_t color, uint8_t sequence) {
-  touchRingActiveColor = color;
-  touchRingActiveSequence = sequence;
+void FingerprintManager::configTouchRingActive(uint8_t color, uint8_t sequence, uint8_t scanColor, uint8_t matchColor ) {
+  this->touchRingActiveColor = color;
+  this->touchRingActiveSequence = sequence;
+  this->scanColor = scanColor;
+  this->matchColor = matchColor;
 }

--- a/src/FingerprintManager.cpp
+++ b/src/FingerprintManager.cpp
@@ -457,7 +457,7 @@ void FingerprintManager::setLedRingWifiConfig() {
 
 void FingerprintManager::setLedRingReady() {
   if (!ignoreTouchRing)
-    finger.LEDcontrol(FINGERPRINT_LED_BREATHING, 250, FINGERPRINT_LED_BLUE);
+    finger.LEDcontrol(touchRingActiveSequence, 250, touchRingActiveColor);
   else
     finger.LEDcontrol(FINGERPRINT_LED_ON, 0, FINGERPRINT_LED_BLUE); // just an indicator for me to see if touch ring is active or not
 }
@@ -558,3 +558,7 @@ void FingerprintManager::importSensorDB() {
 
 }
 
+void FingerprintManager::configTouchRingActive(uint8_t color, uint8_t sequence) {
+  touchRingActiveColor = color;
+  touchRingActiveSequence = sequence;
+}

--- a/src/FingerprintManager.h
+++ b/src/FingerprintManager.h
@@ -49,6 +49,8 @@ class FingerprintManager {
     uint8_t writeNotepad(uint8_t pageNumber, const char *text, uint8_t length);
     uint8_t readNotepad(uint8_t pageNumber, char *text, uint8_t length);
     
+    uint8_t touchRingActiveColor = 2;
+    uint8_t touchRingActiveSequence = 1;
 
 
   public:
@@ -67,6 +69,7 @@ class FingerprintManager {
     String getPairingCode();
     bool setPairingCode(String pairingCode);
     
+    void configTouchRingActive(uint8_t color, uint8_t sequence);
     bool deleteAll();
 
     

--- a/src/FingerprintManager.h
+++ b/src/FingerprintManager.h
@@ -51,6 +51,8 @@ class FingerprintManager {
     
     uint8_t touchRingActiveColor = 2;
     uint8_t touchRingActiveSequence = 1;
+    uint8_t scanColor = 1;
+    uint8_t matchColor = 2;
 
 
   public:
@@ -69,7 +71,7 @@ class FingerprintManager {
     String getPairingCode();
     bool setPairingCode(String pairingCode);
     
-    void configTouchRingActive(uint8_t color, uint8_t sequence);
+    void configTouchRingActive(uint8_t color, uint8_t sequence, uint8_t scanColor, uint8_t matchColor);
     bool deleteAll();
 
     

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -27,6 +27,8 @@ bool SettingsManager::loadAppSettings() {
         appSettings.sensorPairingValid = preferences.getBool("pairingValid", false);
         appSettings.touchRingActiveColor = preferences.getShort("ringActCol", 2);
         appSettings.touchRingActiveSequence = preferences.getShort("ringActSeq", 1);
+        appSettings.scanColor = preferences.getShort("scanColor", 1);
+        appSettings.matchColor = preferences.getShort("matchColor", 3);
         preferences.end();
         return true;
     } else {
@@ -56,6 +58,8 @@ void SettingsManager::saveAppSettings() {
     preferences.putBool("pairingValid", appSettings.sensorPairingValid);
     preferences.putShort("ringActCol", appSettings.touchRingActiveColor);
     preferences.putShort("ringActSeq", appSettings.touchRingActiveSequence);
+    preferences.putShort("scanColor", appSettings.scanColor);
+    preferences.putShort("matchColor", appSettings.matchColor);
     preferences.end();
 }
 

--- a/src/SettingsManager.cpp
+++ b/src/SettingsManager.cpp
@@ -25,6 +25,8 @@ bool SettingsManager::loadAppSettings() {
         appSettings.sensorPin = preferences.getString("sensorPin", "00000000");
         appSettings.sensorPairingCode = preferences.getString("pairingCode", "");
         appSettings.sensorPairingValid = preferences.getBool("pairingValid", false);
+        appSettings.touchRingActiveColor = preferences.getShort("ringActCol", 2);
+        appSettings.touchRingActiveSequence = preferences.getShort("ringActSeq", 1);
         preferences.end();
         return true;
     } else {
@@ -52,6 +54,8 @@ void SettingsManager::saveAppSettings() {
     preferences.putString("sensorPin", appSettings.sensorPin);
     preferences.putString("pairingCode", appSettings.sensorPairingCode);
     preferences.putBool("pairingValid", appSettings.sensorPairingValid);
+    preferences.putShort("ringActCol", appSettings.touchRingActiveColor);
+    preferences.putShort("ringActSeq", appSettings.touchRingActiveSequence);
     preferences.end();
 }
 

--- a/src/SettingsManager.h
+++ b/src/SettingsManager.h
@@ -18,6 +18,8 @@ struct AppSettings {
     String ntpServer = "pool.ntp.org";
     String sensorPin = "00000000";
     String sensorPairingCode = "";
+    int8_t touchRingActiveColor = 2;
+    int8_t touchRingActiveSequence = 1;
     bool   sensorPairingValid = false;
 };
 

--- a/src/SettingsManager.h
+++ b/src/SettingsManager.h
@@ -20,6 +20,8 @@ struct AppSettings {
     String sensorPairingCode = "";
     int8_t touchRingActiveColor = 2;
     int8_t touchRingActiveSequence = 1;
+    int8_t scanColor = 1;
+    int8_t matchColor = 3;
     bool   sensorPairingValid = false;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,6 +24,9 @@ const char* WifiConfigSsid = "FingerprintDoorbell-Config"; // SSID used for WiFi
 const char* WifiConfigPassword = "12345678"; // password used for WiFi when in Access Point mode for configuration. Min. 8 chars needed!
 IPAddress   WifiConfigIp(192, 168, 4, 1); // IP of access point in wifi config mode
 
+const char* Selected = "selected"; // password used for WiFi when in Access Point mode for configuration. Min. 8 chars needed!
+const char* Checked = "checked"; // password used for WiFi when in Access Point mode for configuration. Min. 8 chars needed!
+
 const long  gmtOffset_sec = 0; // UTC Time
 const int   daylightOffset_sec = 0; // UTC Time
 const int   doorbellOutputPin = 19; // pin connected to the doorbell (when using hardware connection instead of mqtt to ring the bell)
@@ -137,6 +140,28 @@ String processor(const String& var){
     return settingsManager.getAppSettings().mqttRootTopic;
   } else if (var == "NTP_SERVER") {
     return settingsManager.getAppSettings().ntpServer;
+  }  else if (var == "TOUCH_RING_ACTIVE_COLOR_1") {
+    return (settingsManager.getAppSettings().touchRingActiveColor == 1) ? Selected : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_COLOR_2") {
+    return (settingsManager.getAppSettings().touchRingActiveColor == 2) ? Selected : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_COLOR_3") {
+    return (settingsManager.getAppSettings().touchRingActiveColor == 3) ? Selected : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_COLOR_4") {
+    return (settingsManager.getAppSettings().touchRingActiveColor == 4) ? Selected : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_COLOR_5") {
+    return (settingsManager.getAppSettings().touchRingActiveColor == 5) ? Selected : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_COLOR_6") {
+    return (settingsManager.getAppSettings().touchRingActiveColor == 6) ? Selected : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_COLOR_7") {
+    return (settingsManager.getAppSettings().touchRingActiveColor == 7) ? Selected : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_SEQUENCE_4") {
+    return (settingsManager.getAppSettings().touchRingActiveSequence == 4) ? Checked : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_SEQUENCE_3") {
+    return (settingsManager.getAppSettings().touchRingActiveSequence == 3) ? Checked : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_SEQUENCE_1") {
+    return (settingsManager.getAppSettings().touchRingActiveSequence == 1) ? Checked : "";
+  }  else if (var == "TOUCH_RING_ACTIVE_SEQUENCE_2") {
+    return (settingsManager.getAppSettings().touchRingActiveSequence == 2) ? Checked : "";
   }
 
   return String();
@@ -357,6 +382,8 @@ void startWebserver(){
         settings.mqttPassword = request->arg("mqtt_password");
         settings.mqttRootTopic = request->arg("mqtt_rootTopic");
         settings.ntpServer = request->arg("ntpServer");
+        settings.touchRingActiveColor = request->arg("touchRingActiveColor").toInt();
+        settings.touchRingActiveSequence = request->arg("touchRingActiveSequence").toInt();
         settingsManager.saveAppSettings(settings);
         request->redirect("/");  
         shouldReboot = true;
@@ -672,8 +699,10 @@ void setup()
           notifyClients("MQTT Server '" + settingsManager.getAppSettings().mqttServer + "' not found. Please check your settings.");
         }
       }
-      if (fingerManager.connected)
+      if (fingerManager.connected) {
+        fingerManager.configTouchRingActive(settingsManager.getAppSettings().touchRingActiveColor,settingsManager.getAppSettings().touchRingActiveSequence);
         fingerManager.setLedRingReady();
+      }
       else
         fingerManager.setLedRingError();
     }  else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,6 +162,34 @@ String processor(const String& var){
     return (settingsManager.getAppSettings().touchRingActiveSequence == 1) ? Checked : "";
   }  else if (var == "TOUCH_RING_ACTIVE_SEQUENCE_2") {
     return (settingsManager.getAppSettings().touchRingActiveSequence == 2) ? Checked : "";
+  }  else if (var == "SCAN_COLOR_1") {
+    return (settingsManager.getAppSettings().scanColor == 1) ? Selected : "";
+  }  else if (var == "SCAN_COLOR_2") {
+    return (settingsManager.getAppSettings().scanColor == 2) ? Selected : "";
+  }  else if (var == "SCAN_COLOR_3") {
+    return (settingsManager.getAppSettings().scanColor == 3) ? Selected : "";
+  }  else if (var == "SCAN_COLOR_4") {
+    return (settingsManager.getAppSettings().scanColor == 4) ? Selected : "";
+  }  else if (var == "SCAN_COLOR_5") {
+    return (settingsManager.getAppSettings().scanColor == 5) ? Selected : "";
+  }  else if (var == "SCAN_COLOR_6") {
+    return (settingsManager.getAppSettings().scanColor == 6) ? Selected : "";
+  }  else if (var == "SCAN_COLOR_7") {
+    return (settingsManager.getAppSettings().scanColor == 7) ? Selected : "";
+  }  else if (var == "MATCH_COLOR_1") {
+    return (settingsManager.getAppSettings().matchColor == 1) ? Selected : "";
+  }  else if (var == "MATCH_COLOR_2") {
+    return (settingsManager.getAppSettings().matchColor == 2) ? Selected : "";
+  }  else if (var == "MATCH_COLOR_3") {
+    return (settingsManager.getAppSettings().matchColor == 3) ? Selected : "";
+  }  else if (var == "MATCH_COLOR_4") {
+    return (settingsManager.getAppSettings().matchColor == 4) ? Selected : "";
+  }  else if (var == "MATCH_COLOR_5") {
+    return (settingsManager.getAppSettings().matchColor == 5) ? Selected : "";
+  }  else if (var == "MATCH_COLOR_6") {
+    return (settingsManager.getAppSettings().matchColor == 6) ? Selected : "";
+  }  else if (var == "MATCH_COLOR_7") {
+    return (settingsManager.getAppSettings().matchColor == 7) ? Selected : "";
   }
 
   return String();
@@ -384,6 +412,8 @@ void startWebserver(){
         settings.ntpServer = request->arg("ntpServer");
         settings.touchRingActiveColor = request->arg("touchRingActiveColor").toInt();
         settings.touchRingActiveSequence = request->arg("touchRingActiveSequence").toInt();
+        settings.scanColor = request->arg("scanColor").toInt();
+        settings.matchColor = request->arg("matchColor").toInt();
         settingsManager.saveAppSettings(settings);
         request->redirect("/");  
         shouldReboot = true;
@@ -715,7 +745,7 @@ void setup()
         }
       }
       if (fingerManager.connected) {
-        fingerManager.configTouchRingActive(settingsManager.getAppSettings().touchRingActiveColor,settingsManager.getAppSettings().touchRingActiveSequence);
+        fingerManager.configTouchRingActive(settingsManager.getAppSettings().touchRingActiveColor,settingsManager.getAppSettings().touchRingActiveSequence,settingsManager.getAppSettings().scanColor,settingsManager.getAppSettings().matchColor);
         fingerManager.setLedRingReady();
       }
       else


### PR DESCRIPTION
In the settings interface there is now the possibility to configure the color and the sequence of the LED.
(For the ready state with activated touch ring, for scanning and for match found)

![image](https://user-images.githubusercontent.com/57706982/204165002-4bb448c2-cafe-4704-bce8-e34cfed53c97.png)

You can choose from 7 colors that are only supported by newer versions of the R503 sensor.
You can turn the LED off. (LED Sequence : Off)

Update: commit [148f432](https://github.com/frickelzeugs/FingerprintDoorbell/pull/26/commits/148f43295be54d36b0445043025a867c2a1459f6)
Parse port number from mqtt server setting if given

![image](https://user-images.githubusercontent.com/57706982/200680491-afcf540b-9f34-48dc-8fa2-2299686862fe.png)


Idea for the future:
Make this feature accessible via MQTT without restart.
Then the color can be used as an indicator for something or the led can be turned on depending on time / sunset/sunrise, etc.